### PR TITLE
moved sudo for aarch64 dependencies

### DIFF
--- a/prepare_system.sh
+++ b/prepare_system.sh
@@ -17,7 +17,7 @@ prepare_ubuntu() {
         $SUDO apt update -y
         $SUDO apt dist-upgrade -y
         $SUDO apt install software-properties-common curl git mc vim facter python python-apt aptitude -y
-        $SUDO [ $(uname -m) == "aarch64" ] && apt install gcc python-dev libffi-dev libssl-dev make -y
+        [ $(uname -m) == "aarch64" ] && $SUDO apt install gcc python-dev libffi-dev libssl-dev make -y
 
         PYTHON_BIN=/usr/bin/python
         install_pip
@@ -34,7 +34,7 @@ prepare_debian() {
         $SUDO apt update -y
         $SUDO apt dist-upgrade -y
         $SUDO apt install dirmngr curl git mc vim facter python python-apt aptitude -y
-        $SUDO [ $(uname -m) == "aarch64" ] && apt install gcc python-dev libffi-dev libssl-dev make -y
+        [ $(uname -m) == "aarch64" ] && $SUDO apt install gcc python-dev libffi-dev libssl-dev make -y
 
         PYTHON_BIN=/usr/bin/python
         install_pip

--- a/roles/prep_nginx/tasks/Debian.yml
+++ b/roles/prep_nginx/tasks/Debian.yml
@@ -24,6 +24,7 @@
   apt:
     name:
     - nginx
+    - nginx-extras
     - python-pip
     - python-netaddr
     autoremove: true


### PR DESCRIPTION
Due to wrong position of `$SUDO` the additional aarch64 dependencies fail to install. `uname` should be accessible without `sudo`, as far as i know. 