### PR TITLE
Add recommendation from Netxcloud doc

### DIFF
--- a/roles/prep_nginx/templates/nextcloud.conf.j2
+++ b/roles/prep_nginx/templates/nextcloud.conf.j2
@@ -30,6 +30,9 @@ server {
 	location = /.well-known/caldav {
 		return 301 $scheme://$host:{{ nc_ssl_port }}/remote.php/dav;
 	}
+	location = /.well-known/webfinger {
+		return 301 $scheme://$host:{{ nc_ssl_port }}/public.php?service=webfinger;
+	}
 {% if install_collabora %}
 
 	location ^~ /loleaflet {


### PR DESCRIPTION
Netxcloud doc recommends to add "/.well-known/webfinger" in webserver config file in addition of carddav and caldav:
https://docs.nextcloud.com/server/17/admin_manual/issues/general_troubleshooting.html#service-discovery