### PR TITLE
Fix missing newlines in nginx template

### DIFF
--- a/roles/prep_nginx/templates/nextcloud.conf.j2
+++ b/roles/prep_nginx/templates/nextcloud.conf.j2
@@ -1,6 +1,7 @@
 server {
 	listen {{ nc_web_port }} default_server;
 	{% if ansible_default_ipv6.address is defined %}listen [::]:{{ nc_web_port }};{% endif %}
+
 	server_name {{ fqdn }};
 	#Your DDNS adress, (e.g. from desec.io or no-ip.com)
 	location ^~ /.well-known/acme-challenge {
@@ -13,6 +14,7 @@ server {
 server {
 	listen {{ nc_ssl_port }} ssl http2 default_server;
 	{% if ansible_default_ipv6.address is defined %}listen [::]:{{ nc_ssl_port }} ssl http2;{% endif %}
+
 	server_name {{ fqdn }};
 	root /var/www/nextcloud/;
 	access_log /var/log/nginx/nextcloud.access.log main;


### PR DESCRIPTION
This change is only cosmetic but makes the nginx configuration more readable.

Before:

         listen [::]:443 ssl http2;      server_name nc.example.org;

After:

         listen [::]:443 ssl http2;
         server_name nc.example.org;