### PR TITLE
add meta/main.yml to be able to use ansible-galaxy

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,6 @@
+galaxy_info:
+  description: ReinerNippes Ansible role to deploy Nextcloud server
+  company: NoCompany
+  min_ansible_version: 2.9
+  platforms:
+    - name: GenericUNIX


### PR DESCRIPTION
usage example:

```
# Import nextcloud role
  pre_tasks:
  - name: "get ansible role with ansible-galaxy"
    command: |
      ansible-galaxy install
      --role-file=tools/requirements.yml
      --roles-path="vendor_roles"
      --force

# requirements.yml
---
- name: ReinerNippes.nextcloud
  src: git+git@github.com:ReinerNippes/nextcloud.git
  version: "master"
```