### PR TITLE
Nextcloud reloaded - run apt update first

### DIFF
--- a/roles/os/tasks/apt.yml
+++ b/roles/os/tasks/apt.yml
@@ -4,6 +4,8 @@
 - name: apt dist-upgrade
   apt:
     upgrade: dist
+    update_cache: yes
+    cache_valid_time: 3600
     autoremove: true
 
 - name: install additional packages


### PR DESCRIPTION
A freshly installed system has not yet run an `apt update`.