### PR TITLE
Fix high security risk of CVSS Score 6.4

### DIFF
--- a/roles/webserver/templates/nginx/nextcloud.conf.j2
+++ b/roles/webserver/templates/nginx/nextcloud.conf.j2
@@ -79,8 +79,6 @@ server {
 
         location = /.well-known/carddav     { return 301 /remote.php/dav/; }
         location = /.well-known/caldav      { return 301 /remote.php/dav/; }
-        # Anything else is dynamically handled by Nextcloud
-        location ^~ /.well-known            { return 301 /index.php$uri; }
 
         try_files $uri $uri/ =404;
     }


### PR DESCRIPTION
According to Detectify an attacker can control all the headers, including the response body.
https://support.detectify.com/support/solutions/articles/48001048954-http-response-splitting-hrs-

Example attack request
https://example.com/.well-known/%0D%0ASplitting:Detectify

I am not a security expert. Can someone please validate this finding?

Kind regards